### PR TITLE
Add the Scala 2.12 flags we should be using.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val root = Project("root", file("."))
     addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"    % BuildInfo.sbtSonatypeVersion),
     addSbtPlugin("com.dwijnand"      % "sbt-travisci"    % BuildInfo.sbtTravisCiVersion),
     addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "1.7.0"),
-    addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "2.0.2"))
+    addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "2.0.3"))
   .settings(publishSettings)
 
 lazy val publishSettings = Publish.commonPublishSettings ++ Seq(


### PR DESCRIPTION
This removes `post210` because it was too constrained. Currently just matches on
the scalaVersion directly whenever necessary. And completely overrides any
default `scalacOptions` rather than appending.

Also update WartRemover (latest version relaxes `PublicInference` on overridden
values).