### PR TITLE
bump wartremover to the latest minor version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val root = Project("root", file("."))
     addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"    % BuildInfo.sbtSonatypeVersion),
     addSbtPlugin("com.dwijnand"      % "sbt-travisci"    % BuildInfo.sbtTravisCiVersion),
     addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "1.7.0"),
-    addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "2.1.0"))
+    addSbtPlugin("org.wartremover"   % "sbt-wartremover" % "2.1.1"))
   .settings(publishSettings)
 
 lazy val publishSettings = Publish.commonPublishSettings ++ Seq(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1"
+version in ThisBuild := "0.3.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2"
+version in ThisBuild := "0.3.1"


### PR DESCRIPTION
This bump avoids a scalaReflection error we were bumping into in version 2.1.0 of wartremover. 



