### PR TITLE
Revert switch to sonatypeRelease

### DIFF
--- a/src/main/resources/publishAndTag
+++ b/src/main/resources/publishAndTag
@@ -20,7 +20,7 @@ if [[
 
   # Only publish on oraclejdk8
   if [[ $JAVA_HOME == *"java-8-oracle" ]]; then
-    sbt ++"$TRAVIS_SCALA_VERSION" 'sonatypeOpen "sbt-slamdata staging"' publishSigned sonatypeRelease
+    sbt ++"$TRAVIS_SCALA_VERSION" publishSigned sonatypeReleaseAll
   else
     echo "Travis not running against oraclejdk8, so skipping publish"
   fi

--- a/src/main/scala/slamdata/Publish.scala
+++ b/src/main/scala/slamdata/Publish.scala
@@ -5,7 +5,6 @@ import sbt._, Keys._
 import com.typesafe.sbt.SbtPgp.autoImportImpl.PgpKeys
 import sbtrelease.ReleasePlugin.autoImport.{
   releaseCrossBuild, releasePublishArtifactsAction}
-import xerial.sbt.Sonatype.SonatypeKeys.sonatypeStagingRepositoryProfile
 
 class Publish {
   lazy val checkHeaders = taskKey[Unit]("Fail the build if createHeaders is not up-to-date")
@@ -17,11 +16,7 @@ class Publish {
       if (isSnapshot.value)
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
-        sonatypeStagingRepositoryProfile.?.value map { stagingRepoProfile =>
-          "releases" at nexus +
-          "service/local/staging/deployByRepositoryId/" +
-          stagingRepoProfile.repositoryId
-        }
+        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
     },
     publishMavenStyle := true,
     publishArtifact in Test := false,


### PR DESCRIPTION
Scoping issues around `sonatypeStagingRepositoryProfile` prevent desired
`publishTo` settings from being applied to subprojects.