### PR TITLE
Use locally forked sbt-bintray publication to solve the staging problem

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import sbtslamdata.BuildInfo
 import slamdata.Publish
 
+resolvers in ThisBuild += Resolver.bintrayIvyRepo("djspiewak", "ivy")
+
 lazy val root = (project in file("."))
   .settings(
     name         := "sbt-slamdata",

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,9 @@
 val sbtPgpVersion      = "1.1.0"
 val sbtReleaseVersion  = "1.0.6"
 val sbtTravisCiVersion = "1.1.1"
-val sbtBintrayVersion = "0.5.3"
+val sbtBintrayVersion = "0.5.3+4-b634b339"
+
+resolvers in ThisBuild += Resolver.bintrayIvyRepo("djspiewak", "ivy")
 
 lazy val root = project.in(file("."))
   .enablePlugins(BuildInfoPlugin)

--- a/src/main/resources/publishAndTag
+++ b/src/main/resources/publishAndTag
@@ -31,6 +31,7 @@ if [[
   # Only publish on oraclejdk8
   if [[ $JAVA_HOME == *"java-8-oracle" ]]; then
     "$SBT" ++"$TRAVIS_SCALA_VERSION" publishSigned synchronizeWithMavenCentral
+    "$SBT" ++"$TRAVIS_SCALA_VERSION" closeMavenCentralStaging
   else
     echo "Travis not running against oraclejdk8, so skipping publish"
   fi


### PR DESCRIPTION
Attn @lukaszwawrzyk.

Everyone is going to need to add the following to their plugins.sbt when including sbt-slamdata, mostly because I'm bad at SBT:

```sbt
resolvers += Resolver.bintrayIvyRepo("djspiewak", "ivy")
```

But I *think* this will fix the sonatype syncing issue.