### PR TITLE
Implemented jcenter atomic releases & support for package.json

### DIFF
--- a/src/main/resources/publishAndTag
+++ b/src/main/resources/publishAndTag
@@ -3,7 +3,14 @@
 set -euo pipefail # STRICT MODE
 IFS=$'\n\t'        # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
-VERSION=$(sed 's/.*"\(.*\)"/\1/' version.sbt)
+if [ -f version.sbt ]; then
+    VERSION=$(sed 's/.*"\(.*\)"/\1/' version.sbt)
+elif [ -f package.json ]; then
+    VERSION=$(jq -r .version package.json | sed 's/v//g')
+else
+    echo "Unable to determine project version required to tag the release on github. Expected to find one of those files: version.sbt, package.json"
+    exit 1
+fi
 
 REPO_SLUG="$1"
 PROJECT=$(sed 's/.*\///' <<< "$REPO_SLUG")

--- a/src/main/resources/publishAndTag
+++ b/src/main/resources/publishAndTag
@@ -30,8 +30,7 @@ if [[
 
   # Only publish on oraclejdk8
   if [[ $JAVA_HOME == *"java-8-oracle" ]]; then
-    "$SBT" ++"$TRAVIS_SCALA_VERSION" publishSigned synchronizeWithMavenCentral
-    "$SBT" ++"$TRAVIS_SCALA_VERSION" closeMavenCentralStaging
+    "$SBT" ++"$TRAVIS_SCALA_VERSION" publishSigned bintrayRelease synchronizeWithSonatypeStaging releaseToMavenCentral
   else
     echo "Travis not running against oraclejdk8, so skipping publish"
   fi


### PR DESCRIPTION
# atomic bintray releases
I added one more thing that we talked about on one call, i.e. atomic bintray releases. This means that if we fail to upload one artifact or something, nothing will be publicly available in slamdata-inc/maven-public nor jCenter. This is kind of done for consistency.

# package.json
I added support for package.json file as a source of version for tagging. After merging this, we will be able to revert hack from slamdata repo that creates version.sbt file.

# refactoring
I did a slight refactoring. 
I adjusted names of two tasks to `synchronizeWithSonatypeStaging` and `releaseToMavenCentral` as this is ultimately our intention.
I kept the `performMavenCentralSync`, it allows to forcefully disable maven central sync (through sonatype). But I gave it the default value of `publishAsOSSProject.value && !sbtPlugin.value`, as we want to only sync open source projects, and it doesn't work for sbt plugins.
This is essentially what `publishAsOSSProject.value && performSonatypeSync.value && !sbtPlugin.value` was checking, "do we want it on maven central?". So the condition simply became `performMavenCentralSync.value`.
So after those changes defaults will still be good. Quasar can override `performMavenCentralSync` as `false` to disable it even though it is an OSS project, but without the override, this would be true.
For slamdata-backend, `publishAsOSSProject` is set to false, which will also set  `performMavenCentralSync` to false and stop it from publishing.