### PR TITLE
triggers

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,9 +1,7 @@
 val sbtPgpVersion      = "1.1.0"
 val sbtReleaseVersion  = "1.0.6"
 val sbtTravisCiVersion = "1.1.1"
-val sbtBintrayVersion = "0.5.3+4-b634b339"
-
-resolvers in ThisBuild += Resolver.bintrayIvyRepo("djspiewak", "ivy")
+val sbtBintrayVersion  = "0.5.4"
 
 lazy val root = project.in(file("."))
   .enablePlugins(BuildInfoPlugin)

--- a/scripts/bumpDependentProject
+++ b/scripts/bumpDependentProject
@@ -1,0 +1,1 @@
+../src/main/resources/bumpDependentProject

--- a/scripts/readVersion
+++ b/scripts/readVersion
@@ -1,0 +1,1 @@
+../src/main/resources/readVersion

--- a/src/main/resources/bumpDependentProject
+++ b/src/main/resources/bumpDependentProject
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # STRICT MODE
+IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
+TARGET_OWNER=$1
+TARGET_REPO=$2
+BUMP_VERSION_FUNC=$3
+
+PROJECT=$(sed 's/.*\///' <<< "$TRAVIS_REPO_SLUG")
+VERSION=$(scripts/readVersion)
+
+
+BRANCH_NAME=$PROJECT-version-bump-$VERSION
+BUMP_MESSAGE="Bump $PROJECT version to $VERSION"
+
+CLONE_DIR=$(mktemp -d "/tmp/slamdata-bump.XXXXXXXX")
+git clone https://$GITHUB_ACCESS_TOKEN@github.com/$TARGET_OWNER/$TARGET_REPO.git $CLONE_DIR
+cd $CLONE_DIR
+git checkout -b $BRANCH_NAME
+$BUMP_VERSION_FUNC $VERSION
+
+git config user.email "builds@travis-ci.com"
+git config user.name "Travis CI"
+
+git commit -am "$BUMP_MESSAGE"
+git push origin $BRANCH_NAME
+
+pull_request_post_data() {
+  cat << EOF
+{
+  "title": "$BUMP_MESSAGE",
+  "head": "$BRANCH_NAME",
+  "base": "master",
+  "body": "This PR was generated automatically."
+}
+EOF
+}
+
+curl -H "Content-Type: application/json" \
+     -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
+     --data "$(pull_request_post_data)" \
+     "https://api.github.com/repos/$TARGET_OWNER/$TARGET_REPO/pulls"
+
+cd -
+rm -rf $CLONE_DIR

--- a/src/main/resources/publishAndTag
+++ b/src/main/resources/publishAndTag
@@ -3,14 +3,7 @@
 set -euo pipefail # STRICT MODE
 IFS=$'\n\t'        # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
-if [ -f version.sbt ]; then
-    VERSION=$(sed 's/.*"\(.*\)"/\1/' version.sbt)
-elif [ -f package.json ]; then
-    VERSION=$(jq -r .version package.json | sed 's/v//g')
-else
-    echo "Unable to determine project version required to tag the release on github. Expected to find one of those files: version.sbt, package.json"
-    exit 1
-fi
+VERSION=$(scripts/readVersion)
 
 REPO_SLUG="$1"
 PROJECT=$(sed 's/.*\///' <<< "$REPO_SLUG")

--- a/src/main/resources/readVersion
+++ b/src/main/resources/readVersion
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # STRICT MODE
+IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
+if [ -f version.sbt ]; then
+    echo $(sed 's/.*"\(.*\)"/\1/' version.sbt)
+elif [ -f package.json ]; then
+    echo $(jq -r .version package.json | sed 's/v//g')
+else
+    echo "Unable to determine project version. Expected to find one of those files: version.sbt, package.json"
+    exit 1
+fi

--- a/src/main/scala/slamdata/SbtSlamData.scala
+++ b/src/main/scala/slamdata/SbtSlamData.scala
@@ -114,10 +114,11 @@ object SbtSlamData extends AutoPlugin {
           (Files.getPosixFilePermissions(dst.toPath).asScala ++ permissions).asJava)
       }
 
-      def transferAllToBaseDir(srcs: String*) = srcs.foreach(src => transfer(src, baseDir / src))
+      def transferToBaseDir(srcs: String*) = srcs.foreach(src => transfer(src, baseDir / src))
+      def transferScripts(srcs: String*) = srcs.foreach(src => transfer(src, baseDir / "scripts" / src, Set(OWNER_EXECUTE)))
 
-      transfer("publishAndTag", baseDir / "scripts" / "publishAndTag", Set(OWNER_EXECUTE))
-      transferAllToBaseDir(
+      transferScripts("publishAndTag", "bumpDependentProject", "readVersion")
+      transferToBaseDir(
         "pubring.pgp.enc",
         "secring.pgp.enc",
         "pgppassphrase.sbt.enc",


### PR DESCRIPTION
This PR is a base for implementing PRs with project bumps.
The core thing is `bumpDependentProject` script, that given repo slug in first 2 args (like quasar-analytics quasar) and a function/script that given assumptions:
 - it is run from that repo from the former params directory
 - $1 arg is the version string to set
should update the version.
This bumping script can be a file, and we can pass a path as argument or a function. Bash functions can be shared with called scripts using `export -f name`.

# Example

When called from quasar during the build as:
```
bumpInSlamdataBackend() { echo $1 > quasar-version; }
export -f bumpInSlamdataBackend
scripts/bumpDependentProject slamdata slamdata-backend bumpInSlamdataBackend
```
It will create a bump commit on a branch called `quasar-version-bump-35.0.0` with commit message `Bump quasar version to 35.0.0` WIth user `Travis CI` and email `builds@travis-ci.com`. It is pushed to the original repo (not a fork). Then a PR to master with title `Bump quasar version to 35.0.0` and message `This PR was generated automatically.` is created.

If any of those names/messages should be changed let me know.

**I am not sure though if this will work from travis. Token would probably need to allow to create branches in repo. If that is not feasible we probably need to create a fork. In that case I will need to analyze this further.**

I extracted version resolving logic as it is needed for both bumping this script and tagging so this PR introduces compatibility with frontend project, which is also done in my other sbt-slamdata PR. They can be merged in any order, I will just fix conflicts.