### PR TITLE
Add skip in publish to default noPublishSettings

### DIFF
--- a/src/main/scala/slamdata/Publish.scala
+++ b/src/main/scala/slamdata/Publish.scala
@@ -49,7 +49,8 @@ class Publish {
   lazy val noPublishSettings = Seq(
     publish := {},
     publishLocal := {},
-    publishArtifact := false
+    publishArtifact := false,
+    skip in publish := true
   )
 
   private def mavenCentralRelatedTask(task: TaskKey[Unit]): Def.Initialize[Task[Unit]] = Def.taskDyn {


### PR DESCRIPTION
As per [this sbt-bintray release](https://github.com/sbt/sbt-bintray/releases/tag/v0.5.4) we can add `skip in publish` setting to subprojects which are not released to disable this plugin there. This should resolve issues like `bintrayEnsureBintrayPackageExists` creating packages for `root` project, and some other non published. It should also avoid unnecessary tasks run when syncing with maven central in future.

This is by no means necessary, but should get things cleaner, so it could be released and bumped in other projects whenever convenient.