### PR TITLE
Fixed releasing as separate step for not published project

### DIFF
--- a/src/main/scala/slamdata/Publish.scala
+++ b/src/main/scala/slamdata/Publish.scala
@@ -49,6 +49,7 @@ class Publish {
   lazy val noPublishSettings = Seq(
     publish := {},
     publishLocal := {},
+    bintrayRelease := {},
     publishArtifact := false,
     skip in publish := true
   )


### PR DESCRIPTION
Seems like it wasn't the sbt-bintray after all, well, kind of...
Problem was caused by spliting release into 2 steps: `publishSigned` and `bintrayRelease`. Publishing always worked correctly because publish and publishLocal tasks were cleared. This is probably not needed now thanks to `skip in publish`. However `bintrayRelease` task fails after publishing because it doesn't care about skipping. In this PR I disabled this task in `noPublishSettings`, and it solves the issue.
 I will see what I can do in sbt-bintray to disable release as well if `skip in publish` is set.
We should release this and bump it in sdbe and quasar PR.