### PR TITLE
Implemented creating missing packages automatically

### DIFF
--- a/src/main/resources/publishAndTag
+++ b/src/main/resources/publishAndTag
@@ -30,7 +30,7 @@ if [[
 
   # Only publish on oraclejdk8
   if [[ $JAVA_HOME == *"java-8-oracle" ]]; then
-    "$SBT" ++"$TRAVIS_SCALA_VERSION" publishSigned bintrayRelease synchronizeWithSonatypeStaging releaseToMavenCentral
+    "$SBT" ++"$TRAVIS_SCALA_VERSION" bintrayEnsureBintrayPackageExists publishSigned bintrayRelease synchronizeWithSonatypeStaging releaseToMavenCentral
   else
     echo "Travis not running against oraclejdk8, so skipping publish"
   fi

--- a/src/main/scala/slamdata/Publish.scala
+++ b/src/main/scala/slamdata/Publish.scala
@@ -51,7 +51,8 @@ class Publish {
     publishLocal := {},
     bintrayRelease := {},
     publishArtifact := false,
-    skip in publish := true
+    skip in publish := true,
+    bintrayEnsureBintrayPackageExists := {}
   )
 
   private def mavenCentralRelatedTask(task: TaskKey[Unit]): Def.Initialize[Task[Unit]] = Def.taskDyn {


### PR DESCRIPTION
@djspiewak 
Latest quasar build failed because there were no packages to publish to for new modules.
This will happen once in a while, when new module is introduced. It requires to go to bintray and create package manually or use `bintrayEnsureBintrayPackageExists` after creating module, but I guess this is easly to be forgotten. It will not create packages for modules that are not published, like `root`.

This PR adds this task to run automatically before each publish. It will make sure all packages exist before publishing.

As for quasar build, I created packages, so it should be enough to rerun build to get things published.