### PR TITLE
Updated year to 2019, only five months late

### DIFF
--- a/src/main/scala/slamdata/SbtSlamData.scala
+++ b/src/main/scala/slamdata/SbtSlamData.scala
@@ -90,7 +90,7 @@ object SbtSlamData extends AutoPlugin {
     def scalacOptions_2_12(strict: Boolean) = Seq("-target:jvm-1.8")
 
     val headerLicenseSettings = Seq(
-      headerLicense := Some(HeaderLicense.ALv2("2014–2018", "SlamData Inc.")),
+      headerLicense := Some(HeaderLicense.ALv2("2014–2019", "SlamData Inc.")),
       licenses += (("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0"))),
       checkHeaders := {
         if ((headerCreate in Compile).value.nonEmpty) sys.error("headers not all present")


### PR DESCRIPTION
Arguably this could be considered **breaking** since it will break the build if downstream projects incorporate it without running a `compile` before committing.