### PR TITLE
Tell scala steward to ignore updates to wart-remover

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [{ groupId = "org.wartremover", artifactId = "sbt-wartremover" }]

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
 - 2.10.6
 - 2.12.3
 jdk:
-- oraclejdk8
+- openjdk8
 env:
 - SBT="./sbt"
 sudo: false


### PR DESCRIPTION
Current versions of Wart Remover do not support Scala 2.10, which
sbt-slamdata compiles to so it can support SBT 0.13.