### PR TITLE
add java home case

### DIFF
--- a/src/main/resources/publishAndTag
+++ b/src/main/resources/publishAndTag
@@ -29,7 +29,7 @@ if [[
   openssl aes-256-cbc -pass pass:"$ENCRYPTION_PASSWORD" -in credentials.sonatype.enc -out local.credentials.sonatype -d
 
   # Only publish on oraclejdk8 or openjdk8
-  if [[ $JAVA_HOME == *java-8-oracle || $JAVA_HOME == *java-1.8.0-openjdk-amd64 ]]; then
+  if [[ $JAVA_HOME == *java-8-oracle || $JAVA_HOME == *java-1.8.0-openjdk-amd64 || $JAVA_HOME == *java-8-openjdk-amd64 ]]; then
     "$SBT" ++"$TRAVIS_SCALA_VERSION" bintrayEnsureBintrayPackageExists publishSigned bintrayRelease synchronizeWithSonatypeStaging releaseToMavenCentral
   else
     echo >&2 "Travis not running against oraclejdk8/openjdk8, so skipping publish (found ${JAVA_HOME})"


### PR DESCRIPTION
With the move to `openjdk8` on Travis the path to java is of the form `/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java` so we need to check for `java-8-openjdk-amd64` in the `publishAndTag` script.