### PR TITLE
Adjusted kind-projector version for cross-build goodness

### DIFF
--- a/src/main/scala/slamdata/SbtSlamData.scala
+++ b/src/main/scala/slamdata/SbtSlamData.scala
@@ -124,8 +124,8 @@ object SbtSlamData extends AutoPlugin {
       autoCompilerPlugins := true,
       autoAPIMappings := true,
 
-      addCompilerPlugin("org.typelevel"   %% "kind-projector"     % "0.10.3"),
-      addCompilerPlugin("com.olegpy"      %% "better-monadic-for" % "0.3.1"),
+      addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.0" cross CrossVersion.full),
+      addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
 
       // default to true
       scalacStrictMode := true,


### PR DESCRIPTION
This is the first version of the plugin that fully works with Scala 2.13