### PR TITLE
Update sbt-trickle to 0.2.0

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -3,5 +3,5 @@ libraryDependencies += "org.yaml" % "snakeyaml" % "1.25"
 addSbtPlugin("io.crashbox"       % "sbt-gpg"            % "0.2.1")
 addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.1-58d9629")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.3.1")
-addSbtPlugin("com.dcsobral"      % "sbt-trickle"        % "0.1.0")
+addSbtPlugin("com.dcsobral"      % "sbt-trickle"        % "0.2.0")
 

--- a/core/src/main/scala/slamdata/SbtSlamDataBase.scala
+++ b/core/src/main/scala/slamdata/SbtSlamDataBase.scala
@@ -268,6 +268,10 @@ abstract class SbtSlamDataBase extends AutoPlugin {
           case _                            => GitConfig(trickleDbURI.value)
         }
       },
+      // FIXME: implement this
+      trickleGithubIsAutobumpPullRequest := (_ => false),
+      // FIXME: implement this
+      // trickleCreatePullRequest := ???,
 
       transferPublishAndTagResources / aggregate := false,
       transferPublishAndTagResources := {


### PR DESCRIPTION
I'm pleasantly surprised there was almost nothing to do. And, at that, I've changed sbt-trickle already in a way that would make this version update go in without any changes whatsoever.

However, we do need to implement the two methods I left as "fixme", so I might as well leave their stubs.